### PR TITLE
Flags parity with Adobe DNG Converter v14.5

### DIFF
--- a/pydngconverter/flags.py
+++ b/pydngconverter/flags.py
@@ -53,6 +53,9 @@ class CRawCompat(CliFlag):
     SIX_SIX = 6.6
     SEVEN_ONE = 7.1
     ELEVEN_TWO = 11.2
+    TWELVE_FOUR = 12.4
+    THIRTEEN_TWO = 13.2
+    FOURTEEN = 14.0
 
     @property
     def name(self):
@@ -65,6 +68,7 @@ class DNGVersion(CliFlag):
     ONE_ONE = 1.1
     ONE_THREE = 1.3
     ONE_FOUR = 1.4
+    ONE_SIX = 1.6
 
     @property
     def name(self):

--- a/tests/test_pydngconverter.py
+++ b/tests/test_pydngconverter.py
@@ -53,7 +53,7 @@ def test_init_setup(with_scenarios, mocker: MockFixture):
         assert mock_resolve.call_count == 2
 
 
-default_args = ["-c", "-cr11.2", "-dng1.4", "-p1"]
+default_args = ["-c", "-cr14.0", "-dng1.6", "-p1"]
 
 
 class DNGParamCase(NamedTuple):


### PR DESCRIPTION
- feat(dng): update flags for parity with latest Adobe DNG Converter v14.5
- test(dng): update defaults args in dng params test cases.
